### PR TITLE
log: Add a structured logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ rustjail = { path = "rustjail" }
 protocols = { path = "protocols" }
 lazy_static = "1.3.0"
 error-chain = "0.12.1"
-log = "0.4.6"
-simple-logging = "2.0.2"
 grpcio = { path = "grpc-rs" }
 protobuf = "2.6.1"
 futures = "0.1.27"
@@ -22,3 +20,13 @@ serde_json = "1.0.39"
 signal-hook = "0.1.9"
 scan_fmt = "0.2.3"
 regex = "1"
+# slog:
+# - Dynamic keys required to allow HashMap keys to be slog::Serialized.
+# - The 'max_*' features allow changing the log level at runtime
+#   (by stopping the compiler from removing log calls).
+slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }
+slog-json = "2.3.0"
+slog-async = "2.3.0"
+slog-scope = "4.1.2"
+# for testing
+tempfile = "3.1.0"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ COMMIT_NO_SHORT := $(shell git rev-parse --short HEAD 2>/dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)
 
+# Exported to allow cargo to see it
+export VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
+
 BUILD_TYPE = release
 
 ARCH = $(shell uname -m)
@@ -61,7 +64,7 @@ check:
 	@cargo test --target $(TRIPLE) --$(BUILD_TYPE)
 
 run:
-	@cargo run --target $(TRIPLE) --$(BUILD_TYPE)
+	@cargo run --target $(TRIPLE)
 
 show-summary: show-header
 	@printf "project:\n"

--- a/rustjail/Cargo.toml
+++ b/rustjail/Cargo.toml
@@ -18,8 +18,8 @@ prctl = "1.0.0"
 lazy_static = "1.3.0"
 libc = "0.2.58"
 protobuf = "2.6.1"
-log = "0.4.6"
+slog = "2.5.2"
+slog-scope = "4.1.2"
 scan_fmt = "0.2"
 regex = "1.1"
 path-absolutize = { git = "git://github.com/magiclen/path-absolutize.git", tag= "v1.1.3" }
-

--- a/rustjail/src/lib.rs
+++ b/rustjail/src/lib.rs
@@ -28,7 +28,7 @@ extern crate lazy_static;
 extern crate libc;
 extern crate protobuf;
 #[macro_use]
-extern crate log;
+extern crate slog;
 #[macro_use]
 extern crate scan_fmt;
 extern crate oci;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,260 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use slog::{BorrowedKV, Drain, Key, OwnedKV, OwnedKVList, Record, KV};
+use std::collections::HashMap;
+use std::io;
+use std::io::Write;
+use std::process;
+use std::result;
+use std::sync::{Arc, Mutex};
+
+// XXX: 'writer' param used to make testing possible.
+pub fn create_logger<W>(name: &str, source: &str, level: slog::Level, writer: W) -> slog::Logger
+where
+    W: Write + Send + Sync + 'static,
+{
+    let json_drain = slog_json::Json::new(writer)
+        .add_default_keys()
+        .build()
+        .fuse();
+
+    // Ensure only a unique set of key/value fields is logged
+    let unique_drain = UniqueDrain::new(json_drain).fuse();
+
+    // Allow runtime filtering of records by log level
+    let filter_drain = RuntimeLevelFilter::new(unique_drain, level).fuse();
+
+    // Ensure the logger is thread-safe
+    let async_drain = slog_async::Async::new(filter_drain).build().fuse();
+
+    // Add some "standard" fields
+    slog::Logger::root(
+        async_drain.fuse(),
+        o!("version" => env!("CARGO_PKG_VERSION"),
+            "subsystem" => "root",
+            "pid" => process::id().to_string(),
+            "name" => name.to_string(),
+            "source" => source.to_string()),
+    )
+}
+
+impl KV for HashSerializer {
+    fn serialize(&self, _record: &Record, serializer: &mut dyn slog::Serializer) -> slog::Result {
+        for (key, value) in self.fields.clone().into_iter() {
+            serializer.emit_str(Key::from(key), &value)?;
+        }
+
+        Ok(())
+    }
+}
+
+// Used to convert an slog::OwnedKVList into a hash map.
+struct HashSerializer {
+    fields: HashMap<String, String>,
+}
+
+impl HashSerializer {
+    fn new() -> HashSerializer {
+        HashSerializer {
+            fields: HashMap::new(),
+        }
+    }
+
+    fn add_field(&mut self, key: String, value: String) {
+        // Take care to only add the first instance of a key. This matters for loggers (but not
+        // Records) since a child loggers have parents and the loggers are serialised child first
+        // meaning the *newest* fields are serialised first.
+        if !self.fields.contains_key(&key) {
+            self.fields.insert(key, value);
+        }
+    }
+
+    fn remove_field(&mut self, key: &str) {
+        self.fields.remove(key);
+    }
+}
+
+impl slog::Serializer for HashSerializer {
+    fn emit_arguments(&mut self, key: Key, value: &std::fmt::Arguments) -> slog::Result {
+        self.add_field(format!("{}", key), format!("{}", value));
+        Ok(())
+    }
+}
+
+struct UniqueDrain<D> {
+    drain: D,
+}
+
+impl<D> UniqueDrain<D> {
+    fn new(drain: D) -> Self {
+        UniqueDrain { drain: drain }
+    }
+}
+
+impl<D> Drain for UniqueDrain<D>
+where
+    D: slog::Drain,
+{
+    type Ok = ();
+    type Err = io::Error;
+
+    fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        let mut logger_serializer = HashSerializer::new();
+        values.serialize(record, &mut logger_serializer)?;
+
+        let mut record_serializer = HashSerializer::new();
+        record.kv().serialize(record, &mut record_serializer)?;
+
+        for (key, _) in record_serializer.fields.iter() {
+            logger_serializer.remove_field(key);
+        }
+
+        let record_owned_kv = OwnedKV(record_serializer);
+        let record_static = record_static!(record.level(), "");
+        let new_record = Record::new(&record_static, record.msg(), BorrowedKV(&record_owned_kv));
+
+        let logger_owned_kv = OwnedKV(logger_serializer);
+
+        let result = self
+            .drain
+            .log(&new_record, &OwnedKVList::from(logger_owned_kv));
+
+        match result {
+            Ok(_t) => Ok(()),
+            Err(_e) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "failed to drain log".to_string(),
+            )),
+        }
+    }
+}
+
+// A RuntimeLevelFilter will discard all log records whose log level is less than the level
+// specified in the struct.
+struct RuntimeLevelFilter<D> {
+    drain: D,
+    level: Arc<Mutex<slog::Level>>,
+}
+
+impl<D> RuntimeLevelFilter<D> {
+    fn new(drain: D, level: slog::Level) -> Self {
+        RuntimeLevelFilter {
+            drain: drain,
+            level: Arc::new(Mutex::new(level)),
+        }
+    }
+
+    fn set_level(&self, level: slog::Level) {
+        let level_ref = self.level.clone();
+
+        let mut log_level = level_ref.lock().unwrap();
+
+        *log_level = level;
+    }
+}
+
+impl<D> Drain for RuntimeLevelFilter<D>
+where
+    D: Drain,
+{
+    type Ok = Option<D::Ok>;
+    type Err = Option<D::Err>;
+
+    fn log(
+        &self,
+        record: &slog::Record,
+        values: &slog::OwnedKVList,
+    ) -> result::Result<Self::Ok, Self::Err> {
+        let level_ref = self.level.clone();
+
+        let log_level = level_ref.lock().unwrap();
+
+        if record.level().is_at_least(*log_level) {
+            self.drain.log(record, values)?;
+        }
+
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::io::prelude::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_create_logger_write_to_tmpfile() {
+        // Create a writer for the logger drain to use
+        let writer = NamedTempFile::new().expect("failed to create tempfile");
+
+        // Used to check file contents before the temp file is unlinked
+        let mut writer_ref = writer.reopen().expect("failed to clone tempfile");
+
+        let level = slog::Level::Trace;
+        let name = "name";
+        let source = "source";
+        let record_subsystem = "record-subsystem";
+
+        let record_key = "record-key-1";
+        let record_value = "record-key-2";
+
+        let logger = create_logger(name, source, level, writer);
+
+        let msg = "foo, bar, baz";
+
+        // Call the logger (which calls the drain)
+        info!(logger, "{}", msg; "subsystem" => record_subsystem, record_key => record_value);
+
+        // Force temp file to be flushed
+        drop(logger);
+
+        let mut contents = String::new();
+        writer_ref
+            .read_to_string(&mut contents)
+            .expect("failed to read tempfile contents");
+
+        // Convert file to JSON
+        let fields: Value =
+            serde_json::from_str(&contents).expect("failed to convert logfile to json");
+
+        // Check the expected JSON fields
+
+        let field_ts = fields.get("ts").expect("failed to find timestamp field");
+        assert_ne!(field_ts, "");
+
+        let field_version = fields.get("version").expect("failed to find version field");
+        assert_eq!(field_version, env!("CARGO_PKG_VERSION"));
+
+        let field_pid = fields.get("pid").expect("failed to find pid field");
+        assert_ne!(field_pid, "");
+
+        let field_level = fields.get("level").expect("failed to find level field");
+        assert_eq!(field_level, "INFO");
+
+        let field_msg = fields.get("msg").expect("failed to find msg field");
+        assert_eq!(field_msg, msg);
+
+        let field_name = fields.get("name").expect("failed to find name field");
+        assert_eq!(field_name, name);
+
+        let field_source = fields.get("source").expect("failed to find source field");
+        assert_eq!(field_source, source);
+
+        let field_subsystem = fields
+            .get("subsystem")
+            .expect("failed to find subsystem field");
+
+        // The records field should take priority over the loggers field of the same name
+        assert_eq!(field_subsystem, record_subsystem);
+
+        let field_record_value = fields
+            .get(record_key)
+            .expect("failed to find record key field");
+        assert_eq!(field_record_value, record_value);
+    }
+}

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use std::thread;
 
 use crate::mount::{BareMount, FLAGS};
+use slog::Logger;
 
 //use container::Process;
 
@@ -47,7 +48,7 @@ pub fn get_current_thread_ns_path(ns_type: &str) -> String {
 
 // setup_persistent_ns creates persistent namespace without switchin to it.
 // Note, pid namespaces cannot be persisted.
-pub fn setup_persistent_ns(ns_type: &'static str) -> Result<Namespace, String> {
+pub fn setup_persistent_ns(logger: Logger, ns_type: &'static str) -> Result<Namespace, String> {
     if let Err(err) = fs::create_dir_all(PERSISTENT_NS_DIR) {
         return Err(err.to_string());
     }
@@ -92,7 +93,7 @@ pub fn setup_persistent_ns(ns_type: &'static str) -> Result<Namespace, String> {
             None => (),
         };
 
-        let bare_mount = BareMount::new(source, destination, "none", flags, "");
+        let bare_mount = BareMount::new(source, destination, "none", flags, "", &logger);
 
         if let Err(err) = bare_mount.mount() {
             return Err(format!(

--- a/src/netlink.rs
+++ b/src/netlink.rs
@@ -19,6 +19,13 @@ use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
+// Convenience macro to obtain the scope logger
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "netlink"))
+    };
+}
+
 // define the struct, const, etc needed by
 // netlink operations
 
@@ -1361,7 +1368,7 @@ impl RtnlHandle {
 
             if done == 1 {
                 if dump_intr == 1 {
-                    info!("dump interuppted, maybe incomplete");
+                    info!(sl!(), "dump interuppted, maybe incomplete");
                 }
 
                 break;
@@ -1398,6 +1405,7 @@ impl RtnlHandle {
 
                 if (*nlh).nlmsg_len < NLMSG_SPACE!(mem::size_of::<ifinfomsg>()) {
                     info!(
+                        sl!(),
                         "invalid nlmsg! nlmsg_len: {}, nlmsg_space: {}",
                         (*nlh).nlmsg_len,
                         NLMSG_SPACE!(mem::size_of::<ifinfomsg>())
@@ -1444,6 +1452,7 @@ impl RtnlHandle {
                     let tlen = NLMSG_SPACE!(mem::size_of::<ifaddrmsg>());
                     if (*alh).nlmsg_len < tlen {
                         info!(
+                            sl!(),
                             "invalid nlmsg! nlmsg_len: {}, nlmsg_space: {}",
                             (*alh).nlmsg_len,
                             tlen
@@ -1566,6 +1575,7 @@ impl RtnlHandle {
 
                 if (*nlh).nlmsg_len < NLMSG_SPACE!(mem::size_of::<ifinfomsg>()) {
                     info!(
+                        sl!(),
                         "invalid nlmsg! nlmsg_len: {}, nlmsg_space: {}",
                         (*nlh).nlmsg_len,
                         NLMSG_SPACE!(mem::size_of::<ifinfomsg>())
@@ -1792,6 +1802,7 @@ impl RtnlHandle {
                 let tlen = NLMSG_SPACE!(mem::size_of::<ifaddrmsg>());
                 if (*nlh).nlmsg_len < tlen {
                     info!(
+                        sl!(),
                         "invalid nlmsg! nlmsg_len: {}, nlmsg_space: {}",
                         (*nlh).nlmsg_len,
                         tlen
@@ -1991,13 +2002,13 @@ impl RtnlHandle {
                 let ifi: *mut ifinfomsg = NLMSG_DATA!(nlh) as *mut ifinfomsg;
 
                 if (*nlh).nlmsg_type != RTM_NEWLINK && (*nlh).nlmsg_type != RTM_DELLINK {
-                    info!("wrong message!");
+                    info!(sl!(), "wrong message!");
                     continue;
                 }
 
                 let tlen = NLMSG_SPACE!(mem::size_of::<ifinfomsg>());
                 if (*nlh).nlmsg_len < tlen {
-                    info!("corrupt message?");
+                    info!(sl!(), "corrupt message?");
                     continue;
                 }
 
@@ -2034,13 +2045,14 @@ impl RtnlHandle {
                 let rtm: *const rtmsg = NLMSG_DATA!(nlh) as *const rtmsg;
 
                 if (*nlh).nlmsg_type != RTM_NEWROUTE && (*nlh).nlmsg_type != RTM_DELROUTE {
-                    info!("not route message!");
+                    info!(sl!(), "not route message!");
                     continue;
                 }
 
                 let tlen = NLMSG_SPACE!(mem::size_of::<rtmsg>());
                 if (*nlh).nlmsg_len < tlen {
                     info!(
+                        sl!(),
                         "invalid nlmsg! nlmsg_len: {}, nlmsg_spae: {}",
                         (*nlh).nlmsg_len,
                         tlen
@@ -2124,9 +2136,9 @@ impl RtnlHandle {
                         np);
 
                     if tn as i64 == 0 {
-                        info!("no name?");
+                        info!(sl!(), "no name?");
                     } else {
-                        info!("name(indextoname): {}", String::from_utf8(n)?);
+                        info!(sl!(), "name(indextoname): {}", String::from_utf8(n)?);
                     }
                     // std::process::exit(-1);
                     */
@@ -2177,13 +2189,14 @@ impl RtnlHandle {
                 let rtm: *const rtmsg = NLMSG_DATA!(nlh) as *const rtmsg;
 
                 if (*nlh).nlmsg_type != RTM_NEWROUTE && (*nlh).nlmsg_type != RTM_DELROUTE {
-                    info!("not route message!");
+                    info!(sl!(), "not route message!");
                     continue;
                 }
 
                 let tlen = NLMSG_SPACE!(mem::size_of::<rtmsg>());
                 if (*nlh).nlmsg_len < tlen {
                     info!(
+                        sl!(),
                         "invalid nlmsg! nlmsg_len: {}, nlmsg_spae: {}",
                         (*nlh).nlmsg_len,
                         tlen
@@ -2349,7 +2362,7 @@ impl RtnlHandle {
     }
 
     fn delete_one_route(&mut self, r: &RtRoute) -> Result<()> {
-        info!("delete route");
+        info!(sl!(), "delete route");
         let mut v: Vec<u8> = vec![0; 2048];
         unsafe {
             let mut nlh: *mut nlmsghdr = v.as_mut_ptr() as *mut nlmsghdr;


### PR DESCRIPTION
Switch from using the `log` crate to the `slog` crate to provide "structured logging" capability.

There are a few complications:

- `slog` allows multiple fields with the same name to appear in the log output. Since we want unique log fields (like `logrus`), I've implemented a custom `slog` `Drain` that collapses the fields into a
  unique set in the correct order.

- The auto-generated gRPC code requires static lifetimes. This means we cannot pass (dynamic) logger objects around that part of the codebase. To solve this problem, we register a global `slog` logger that is accessed via the `sl!()` macro by the gRPC code.

- Some parts of the code don't lend themselves to adding a logger object to be passed around. Those areas also make use of a custom `sl!()` macro to provide a quick solution to the logger passing issue.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>