### PR TITLE
Macro and logging fixes

### DIFF
--- a/rustjail/src/container.rs
+++ b/rustjail/src/container.rs
@@ -49,7 +49,6 @@ use protobuf::{CachedSize, SingularPtrField, UnknownFields};
 use oci::State as OCIState;
 use std::collections::HashMap;
 
-#[macro_use]
 use slog::{debug, info, o, Logger};
 
 const STATE_FILENAME: &'static str = "state.json";

--- a/rustjail/src/lib.rs
+++ b/rustjail/src/lib.rs
@@ -35,6 +35,13 @@ extern crate oci;
 extern crate path_absolutize;
 extern crate regex;
 
+// Convenience macro to obtain the scope logger
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "rustjail"))
+    };
+}
+
 pub mod cgroups;
 pub mod container;
 pub mod errors;

--- a/rustjail/src/mount.rs
+++ b/rustjail/src/mount.rs
@@ -442,7 +442,12 @@ fn mount_from(m: &Mount, rootfs: &str, flags: MsFlags, data: &str, _label: &str)
         match fs::create_dir_all(&dir) {
             Ok(_) => {}
             Err(e) => {
-                //info!("creat dir {}: {}", dir.to_str().unwrap(), e.to_string());
+                info!(
+                    sl!(),
+                    "creat dir {}: {}",
+                    dir.to_str().unwrap(),
+                    e.to_string()
+                );
             }
         }
 
@@ -456,7 +461,7 @@ fn mount_from(m: &Mount, rootfs: &str, flags: MsFlags, data: &str, _label: &str)
         PathBuf::from(&m.source)
     };
 
-    //info!("{}, {}", src.to_str().unwrap(), dest.as_str());
+    info!(sl!(), "{}, {}", src.to_str().unwrap(), dest.as_str());
 
     // ignore this check since some mount's src didn't been a directory
     // such as tmpfs.
@@ -472,7 +477,7 @@ fn mount_from(m: &Mount, rootfs: &str, flags: MsFlags, data: &str, _label: &str)
     match stat::stat(dest.as_str()) {
         Ok(_) => {}
         Err(e) => {
-            //info!("{}: {}", dest.as_str(), e.as_errno().unwrap().desc());
+            info!(sl!(), "{}: {}", dest.as_str(), e.as_errno().unwrap().desc());
         }
     }
 
@@ -485,7 +490,7 @@ fn mount_from(m: &Mount, rootfs: &str, flags: MsFlags, data: &str, _label: &str)
     ) {
         Ok(_) => {}
         Err(e) => {
-            //info!("mount error: {}", e.as_errno().unwrap().desc());
+            info!(sl!(), "mount error: {}", e.as_errno().unwrap().desc());
             return Err(e.into());
         }
     }
@@ -508,7 +513,12 @@ fn mount_from(m: &Mount, rootfs: &str, flags: MsFlags, data: &str, _label: &str)
             None::<&str>,
         ) {
             Err(e) => {
-                //info!("remout {}: {}", dest.as_str(), e.as_errno().unwrap().desc());
+                info!(
+                    sl!(),
+                    "remout {}: {}",
+                    dest.as_str(),
+                    e.as_errno().unwrap().desc()
+                );
                 return Err(e.into());
             }
             Ok(_) => {}
@@ -613,7 +623,7 @@ fn bind_dev(dev: &LinuxDevice) -> Result<()> {
 
 pub fn finish_rootfs(spec: &Spec) -> Result<()> {
     let olddir = unistd::getcwd()?;
-    //info!("{}", olddir.to_str().unwrap());
+    info!(sl!(), "{}", olddir.to_str().unwrap());
     unistd::chdir("/")?;
     if spec.Linux.is_some() {
         let linux = spec.Linux.as_ref().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,18 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//extern crate oci;
-//extern crate rustjail;
-#![feature(map_get_key_value)]
 #![allow(non_camel_case_types)]
 #![allow(unused_parens)]
-// #![allow(deprecated)]
-// #![allow(unused_imports)]
-// #![allow(unreachable_code)]
-// #![allow(unused_assignments)]
-// #![allow(unused_variables)]
-// #![allow(unused_mut)]
-// #![allow(unused_must_use)]
 #![allow(unused_unsafe)]
 #![allow(dead_code)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
Commit d63884a6f5f1c1fcbf7ad33878c732be09391f0c inadvertently removed a number of log calls, so add them back, referencing the scoped logger.

Also deleted commented out and redundant macros.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>