### PR TITLE
tests: Add debug console tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,10 +26,6 @@ extern crate slog_async;
 extern crate slog_json;
 
 use futures::*;
-use std::fs;
-//use std::io::Read;
-use std::{io, thread};
-//use lazy_static::{self, initialize};
 use nix::sys::wait::{self, WaitStatus};
 use nix::unistd;
 use prctl::set_child_subreaper;
@@ -37,11 +33,13 @@ use rustjail::errors::*;
 use signal_hook::{iterator::Signals, SIGCHLD};
 use std::collections::HashMap;
 use std::env;
+use std::fs;
 use std::os::unix::fs::{self as unixfs};
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex};
+use std::{io, thread};
 use unistd::Pid;
 
 mod device;

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ fn setup_signal_handler(logger: &Logger, sandbox: Arc<Mutex<Sandbox>>) -> Result
 
     set_child_subreaper(true).map_err(|err| {
         format!(
-            "failed  to setup agent as a child subreaper, failed with {}",
+            "failed to setup agent as a child subreaper, failed with {}",
             err
         )
     })?;


### PR DESCRIPTION
Add initial tests for the debug console feature. This required changing the lazy static vector of shells to use an arc mutex (so it's thread-safe and mutable). The vector is also initialised to an empty list for the tests, but set to the standard set of shells for release builds.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>