### PR TITLE
Test parse cmdline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ clean:
 	@cargo clean
 
 check:
-	@cargo test --target $(TRIPLE) --$(BUILD_TYPE)
+	@cargo test --target $(TRIPLE)
 
 run:
 	@cargo run --target $(TRIPLE)


### PR DESCRIPTION
Use a table-based approach to add unit tests for exercising the `parse_cmdline()` function.

Also, fix running tests by removing `--release`, which causes `cargo test` to fail.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>