### PR TITLE
tests: Stop debug console tests racing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,12 @@ fn main() -> Result<()> {
 
         thread::spawn(move || {
             let shells = shells.lock().unwrap();
-            let _ = setup_debug_console(shells.to_vec());
+            let result = setup_debug_console(shells.to_vec());
+            if result.is_err() {
+                // Report error, but don't fail
+                warn!(thread_logger, "failed to setup debug console";
+                    "error" => format!("{}", result.unwrap_err()));
+            }
         })
     } else {
         unsafe { MaybeUninit::zeroed().assume_init() }


### PR DESCRIPTION
Add a guard variable to allow the debug console tests to run in any order; previously they could fail as there was an implicit ordering - `test_setup_debug_console_no_shells()` needed to run first (when no
shells were defined).

Fixes: #28.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>